### PR TITLE
Feature/passport

### DIFF
--- a/config/passport.js
+++ b/config/passport.js
@@ -1,5 +1,28 @@
 const passport = require('passport')
+const passportJWT = require('passport-jwt')
+const ExtractJwt = passportJWT.ExtractJwt
+const JwtStrategy = passportJWT.Strategy
+const jwtOptions = {
+  jwtFromRequest: ExtractJwt.fromAuthHeaderAsBearerToken(),
+  secretOrKey: process.env.JWT_SECRET
+}
 
+const { User } = require('../models')
 
+const strategy = new JwtStrategy(jwtOptions, async function (
+  jwt_payload,
+  next
+) {
+  const user = await User.findByPk(jwt_payload.id, {
+    include: [
+      { model: User, as: 'Followers' },
+      { model: User, as: 'Followings' }
+    ]
+  })
+  if (!user) return next(null, false)
+  return next(null, user)
+})
+
+passport.use(strategy)
 
 module.exports = passport

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -17,4 +17,4 @@ const authenticatedRole = (role) => {
   }
 }
 
-module.exports = authenticated
+module.exports = { authenticated, authenticatedRole }

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -6,4 +6,15 @@ const helpers = require('../_helpers')
 // use helpers.getUser(req) to replace req.user
 const authenticated = passport.authenticate('jwt', { session: false })
 
+// authenticatedRole('user') to verify req is user
+// authenticatedRole('admin') to verify req is admin
+const authenticatedRole = (role) => {
+  return (req, res, next) => {
+    if (helpers.getUser(req).role !== role) {
+      return res.json({ status: 'error', message: 'Permission denied' })
+    }
+    return next()
+  }
+}
+
 module.exports = authenticated

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -1,9 +1,9 @@
 const jwt = require('jsonwebtoken')
-const { User, sequelize } = require('../models')
+const { User } = require('../models')
 const passport = require('../config/passport')
 const helpers = require('../_helpers')
 
 // use helpers.getUser(req) to replace req.user
-const authenticated = (req, res, next) => {}
+const authenticated = passport.authenticate('jwt', { session: false })
 
 module.exports = authenticated


### PR DESCRIPTION
1. Passport-jwt 的 策略設定
2. 新增authenticated middleware 用於驗證req 是否為登入的user
3. 新增authenticatedRole middleware 用於驗證req的role
  - >authenticatedRole('user') 當req.user.role = admin 會回傳 Permission denied
  - >authenticatedRole('user') 當req.user.role = user 可以進到下一個middleware 或是路由
  - >authenticatedRole('admin') 當req.user.role = user 會回傳 Permission denied
  - >authenticatedRole('admin') 當req.user.role = admin 可以進到下一個middleware 或是路由


