### PR TITLE
fix: modify passport authenticate in auth for passing unit test

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,5 @@
+{
+  "prettier.trailingComma": "none",
+  "prettier.semi": false,
+  "prettier.singleQuote": true
+}

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -4,14 +4,29 @@ const passport = require('../config/passport')
 const helpers = require('../_helpers')
 
 // use helpers.getUser(req) to replace req.user
-const authenticated = passport.authenticate('jwt', { session: false })
+const authenticated = (req, res, next) =>
+  passport.authenticate('jwt', { session: false }, (err, user) => {
+    if (err) {
+      return new Error(err)
+    }
+    // Check if the user exists
+    if (!user) {
+      return res
+        .status(401)
+        .json({ status: 'error', message: 'Permission denied' })
+    }
+
+    return next()
+  })
 
 // authenticatedRole('user') to verify req is user
 // authenticatedRole('admin') to verify req is admin
 const authenticatedRole = (role) => {
   return (req, res, next) => {
     if (helpers.getUser(req).role !== role) {
-      return res.json({ status: 'error', message: 'Permission denied' })
+      return res
+      .status(401)
+      .json({ status: 'error', message: 'Permission denied' })
     }
     return next()
   }


### PR DESCRIPTION
由於目前的 middleware authenticated 會導致無法通過 unit test
所以參照 passport jwt 官網 http://www.passportjs.org/packages/passport-jwt/
去修改 middleware，補上一些錯誤處理並加上 return next()