### PR TITLE
Hotfix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -115,3 +115,7 @@ typings/
 
 temp/
 upload/
+
+# vscode settings
+
+.vscode

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -4,14 +4,29 @@ const passport = require('../config/passport')
 const helpers = require('../_helpers')
 
 // use helpers.getUser(req) to replace req.user
-const authenticated = passport.authenticate('jwt', { session: false })
+const authenticated = (req, res, next) =>
+  passport.authenticate('jwt', { session: false }, (err, user) => {
+    if (err) {
+      return new Error(err)
+    }
+    // Check if the user exists
+    if (!user) {
+      return res
+        .status(401)
+        .json({ status: 'error', message: 'Permission denied' })
+    }
+
+    return next()
+  })
 
 // authenticatedRole('user') to verify req is user
 // authenticatedRole('admin') to verify req is admin
 const authenticatedRole = (role) => {
   return (req, res, next) => {
     if (helpers.getUser(req).role !== role) {
-      return res.json({ status: 'error', message: 'Permission denied' })
+      return res
+      .status(401)
+      .json({ status: 'error', message: 'Permission denied' })
     }
     return next()
   }


### PR DESCRIPTION
1. middleware 相關

由於 middleware 中的 authenticated 會導致自動化測試檔案無法通過測試
因此參照 passport 官網的 jwt 範例改寫 http://www.passportjs.org/packages/passport-jwt/
加上錯誤處理與 return next()

2. gitignore

加上 .vscode 防止紀錄 vscode 設定檔