### PR TITLE
Hotfix

### DIFF
--- a/services/userService.js
+++ b/services/userService.js
@@ -212,7 +212,7 @@ const userService = {
 
   getTopUsers: async (currentUserId) => {
     return await User.findAll({
-      where: { id: { [Op.not]: currentUserId } },
+      where: { id: { [Op.not]: currentUserId }, role: 'user' },
       include: [
         {
           model: User,

--- a/services/userService.js
+++ b/services/userService.js
@@ -12,8 +12,8 @@ const userService = {
       where: { id },
       attributes: { exclude: ['password'] },
       include: [
-        { model: User, as: 'Followers' },
-        { model: User, as: 'Followings' },
+        { model: User, as: 'Followers', attributes: { exclude: ['password'] } },
+        { model: User, as: 'Followings', attributes: { exclude: ['password'] } },
         { model: Like }
       ]
     })


### PR DESCRIPTION
修正：

- GET /api/users/top (撈取前十名熱門使用者時，須排除管理者，僅顯示一般使用者)
- GET /api/users/current_user (撈取目前登入使用者時，也要移除其追隨者、正在追隨者的 password 資料)

測試：

- 已通過 POSTMAN 測試

![修正getTopUsers(postman)](https://user-images.githubusercontent.com/78346513/133547749-8cae1395-5eea-4bee-96b9-8da75982cbbf.png)

![修正getCurrentUsers(POSTMAN)](https://user-images.githubusercontent.com/78346513/133547757-9d3fb3e8-cc4a-4344-9b2b-3e2c3c2c4881.png)



- 自動化測試 (兩者完成後統一進行)

![修正getTopUsers(自動化測試)](https://user-images.githubusercontent.com/78346513/133547768-7adaef9c-40c4-4b84-aeff-9818385cbd9d.png)

備註：

- 因為更動範圍僅限 userService，不會與另一個 feature/validator 的重構範圍 conflict 