### PR TITLE
fix: order data with join table attributes in userService

### DIFF
--- a/services/userService.js
+++ b/services/userService.js
@@ -198,7 +198,7 @@ const userService = {
         ]
       ],
       group: ['TweetId'],
-      order: [['createdAt', 'DESC']]
+      order: [['Likes', 'createdAt', 'DESC']]
     })
   },
 
@@ -229,7 +229,7 @@ const userService = {
         'account'
       ],
       group: ['User.id'],
-      order: [['createdAt', 'DESC']]
+      order: [['Followers', 'createdAt', 'DESC']]
     })
   },
 
@@ -260,7 +260,7 @@ const userService = {
         'account'
       ],
       group: ['User.id'],
-      order: [['createdAt', 'DESC']]
+      order: [['Followings', 'createdAt', 'DESC']]
     })
   },
 


### PR DESCRIPTION
修改：

- getUserLikedTweets (以 Like 建立的時間，而非 Tweet 建立的時間排序)

![userLikedTweets(postman)](https://user-images.githubusercontent.com/78346513/133740089-401c8107-594e-4efd-92fb-37efe977172b.png)


- getUserFollowings (以 Followship 建立的時間，而非 User 建立的時間排序)
![userFollowings(postman)](https://user-images.githubusercontent.com/78346513/133740119-6f1750aa-cfd7-44c5-8991-4ca5fc2a48ee.png)


- getUserFollowers (以 Followship 建立的時間，而非 User 建立的時間排序)
![userFollowers(postman)](https://user-images.githubusercontent.com/78346513/133740133-fcb33f35-dac3-413c-81fd-6b2a3079e0ef.png)



自動化測試：
![userFollowers(自動化)](https://user-images.githubusercontent.com/78346513/133740077-a55e72aa-8120-4131-967b-ecee69ef84fa.png)


