### PR TITLE
fix: modify tweet's replies to descending order with createdAt attrib…

### DIFF
--- a/services/tweetService.js
+++ b/services/tweetService.js
@@ -76,7 +76,8 @@ const tweetService = {
         'createdAt',
         'updatedAt'
       ],
-      group: 'Replies.id'
+      group: 'Replies.id',
+      order: [['Replies', 'createdAt', 'DESC']]
     })
   },
   postTweet: async (UserId, description) => {


### PR DESCRIPTION
修改：

- GET /api/tweets/:tweetId  回傳資料中的 Replies 按照時間由新到舊排序

測試：

- 自動化測試

![tweetIdSort(自動化測試)](https://user-images.githubusercontent.com/78346513/133762349-4ac5ebe8-c8f1-4b31-9979-4eaa0f007b88.png)


- POSTMAN 測試

![tweetIdSort(postman)](https://user-images.githubusercontent.com/78346513/133762324-c2502439-e4ef-48b1-a800-41c379e20c29.png)
![tweetIdSort(postman1)](https://user-images.githubusercontent.com/78346513/133762329-42e18a62-6f31-427a-8da8-b1d9b6222b53.png)



P.S. 由於此項修正前，POSTMAN 的輸出結果就是由新到舊排序，但前端打 Heroku 依然得到由舊到新的錯誤結果。
因此在修改時有特意將 order 設為 'ASC' ，確認本地 POSTMAN 輸出結果會變成由舊到新，再改為 'DESC' 後也轉變為由新到舊的預期結果。但仍無法百分之百確定此次修正可以解決問題。


