### PR TITLE
Hotfix

### DIFF
--- a/utils/validator.js
+++ b/utils/validator.js
@@ -87,7 +87,7 @@ const joiMessageHandler = (errors) => {
       }
         messages.push(error.message)
     })
-    return messages
+    return messages.join('|')
 }
 
 module.exports = {


### PR DESCRIPTION
修改：

- validator.js 的 joiMessageHandler() 回傳錯誤訊息陣列時，改用 | 區隔不同的錯誤訊息

測試：

- 已通過自動化測試
![errorwithnew(測試)](https://user-images.githubusercontent.com/78346513/134172123-7bec6deb-9c5f-4283-b728-53a08c8f5074.png)



- 已通過 POSTMAN 測試
![errorwithnew](https://user-images.githubusercontent.com/78346513/134172105-58153c1a-ed30-4593-b15a-30139c2524cf.png)

