### PR TITLE
feat: add error message to joi userInfo schema

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -278,7 +278,7 @@ const userController = {
             req.body.cover = coverData.link
           }
         } catch (error) {
-          next(new ApiError('UploadImageError', 400, 'Upload image Failed'))
+          next(new ApiError('UploadImageError', 400, 'Upload image failed'))
         }
       }
 

--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -267,14 +267,18 @@ const userController = {
       const { files } = req
 
       if (files) {
-        imgur.setClientId(IMGUR_CLIENT_ID)
-        if (files.avatar) {
-          const avatarData = await imgur.uploadFile(files.avatar[0].path)
-          req.body.avatar = avatarData.link
-        }
-        if (files.cover) {
-          const coverData = await imgur.uploadFile(files.cover[0].path)
-          req.body.cover = coverData.link
+        try {
+          imgur.setClientId(IMGUR_CLIENT_ID)
+          if (files.avatar) {
+            const avatarData = await imgur.uploadFile(files.avatar[0].path)
+            req.body.avatar = avatarData.link
+          }
+          if (files.cover) {
+            const coverData = await imgur.uploadFile(files.cover[0].path)
+            req.body.cover = coverData.link
+          }
+        } catch (error) {
+          next(new ApiError('UploadImageError', 400, 'Upload image Failed'))
         }
       }
 

--- a/utils/validator.js
+++ b/utils/validator.js
@@ -49,19 +49,7 @@ const userInfoSchema = Joi.object({
     .messages({
       'string.base':'Data type of introduction must be a string',
       'string.max': 'The introduction should not exceed 160 words'
-    }),
-  avatar: Joi.string()
-    .trim()
-    .allow('')
-    .messages({
-      'string.base':'Upload avatar failed'
-    }),
-  cover: Joi.string()
-    .trim()
-    .allow('')
-    .messages({
-      'string.base':'Upload cover failed'
-    }),
+    })
 })
 
 // Joi schema for validating tweet format

--- a/utils/validator.js
+++ b/utils/validator.js
@@ -50,8 +50,18 @@ const userInfoSchema = Joi.object({
       'string.base':'Data type of introduction must be a string',
       'string.max': 'The introduction should not exceed 160 words'
     }),
-  avatar: Joi.string().trim().allow(''),
-  cover: Joi.string().trim().allow('')
+  avatar: Joi.string()
+    .trim()
+    .allow('')
+    .messages({
+      'string.base':'Upload avatar failed'
+    }),
+  cover: Joi.string()
+    .trim()
+    .allow('')
+    .messages({
+      'string.base':'Upload cover failed'
+    }),
 })
 
 // Joi schema for validating tweet format


### PR DESCRIPTION
修改：

- 新增 avatar, cover 的錯誤訊息 (validator.js)

測試：

- 已通過自動化測試

![errorwithnew(測試)](https://user-images.githubusercontent.com/78346513/134185174-f642f6fb-8400-484a-b7f0-ebb04a8231b8.png)

