### PR TITLE
refactor: Modify POST /users/signin & POST /admin/signin to use email

### DIFF
--- a/controllers/userController.js
+++ b/controllers/userController.js
@@ -11,7 +11,7 @@ const ApiError = require('../utils/customError')
 const userController = {
   signIn: async (req, res, next) => {
     try {
-      const { account, password } = req.body
+      const { email, password } = req.body
 
       // Check request body data format with Joi schema
       const { error } = userInfoSchema.validate(req.body, { abortEarly: false })
@@ -24,8 +24,8 @@ const userController = {
         )
       }
 
-      // Check whether the user exists by account
-      const user = await userService.signIn(account)
+      // Check whether the user exists by email
+      const user = await userService.signIn(email)
 
       if (!user) {
         throw new ApiError('UserSingInError', 401, 'No such user found')

--- a/services/userService.js
+++ b/services/userService.js
@@ -4,8 +4,12 @@ const ApiError = require('../utils/customError')
 const { checkUserInfoUniqueness } = require('../utils/validator')
 
 const userService = {
-  signIn: async (account) => {
-    return await User.findOne({ where: { account: Sequelize.where(Sequelize.literal(`BINARY account`), `${account}`) } })
+  signIn: async (email) => {
+    return await User.findOne({
+      where: {
+        account: Sequelize.where(Sequelize.literal(`BINARY email`), `${email}`)
+      }
+    })
   },
 
   getCurrentUser: async (id) => {


### PR DESCRIPTION
修改：

- 前/後台統一使用email、password進行登入，因此修改原本signin邏輯從account 更改為email。

測試：

- Postman測試:

POST /api/users/signin
![Screen Shot 2021-09-23 at 11 30 07 AM](https://user-images.githubusercontent.com/24835719/134450875-a0ec42f2-fd4c-420f-bac3-da77ea7f6f5e.png)PUT /api/users

![Screen Shot 2021-09-23 at 11 25 04 AM](https://user-images.githubusercontent.com/24835719/134450895-680e2d72-f363-4325-b9b1-3bc435dae4b8.png)

POST /api/admin/signin
![Screen Shot 2021-09-23 at 11 25 53 AM](https://user-images.githubusercontent.com/24835719/134450916-fb3eba79-edca-472b-a6f3-28e7acc15a63.png)

- 已通過自動化測試
![image](https://user-images.githubusercontent.com/24835719/134450996-616bf1a5-31e0-403a-bc81-d8e7946c3b97.png)
