### PR TITLE
Hotfix

### DIFF
--- a/services/userService.js
+++ b/services/userService.js
@@ -220,10 +220,11 @@ const userService = {
         'name',
         'avatar',
         'introduction',
-        'account'
+        'account',
+        [Sequelize.col('Followers.Followship.createdAt'), 'createdAt']
       ],
       group: ['User.id'],
-      order: [['Followers', 'createdAt', 'DESC']]
+      order: [[Sequelize.col('Followers.Followship.createdAt'), 'DESC']]
     })
   },
 
@@ -251,10 +252,11 @@ const userService = {
         'name',
         'avatar',
         'introduction',
-        'account'
+        'account',
+        [Sequelize.col('Followings.Followship.createdAt'), 'createdAt']
       ],
       group: ['User.id'],
-      order: [['Followings', 'createdAt', 'DESC']]
+      order: [[Sequelize.col('Followings.Followship.createdAt'), 'DESC']]
     })
   },
 

--- a/services/userService.js
+++ b/services/userService.js
@@ -220,8 +220,7 @@ const userService = {
         'name',
         'avatar',
         'introduction',
-        'account',
-        [Sequelize.col('Followers.Followship.createdAt'), 'createdAt']
+        'account'
       ],
       group: ['User.id'],
       order: [[Sequelize.col('Followers.Followship.createdAt'), 'DESC']]
@@ -252,8 +251,7 @@ const userService = {
         'name',
         'avatar',
         'introduction',
-        'account',
-        [Sequelize.col('Followings.Followship.createdAt'), 'createdAt']
+        'account'
       ],
       group: ['User.id'],
       order: [[Sequelize.col('Followings.Followship.createdAt'), 'DESC']]


### PR DESCRIPTION
錯誤與修正：

getUserFollowings 與 getUserFollowers 沒有正確依照由新到舊的方式排序追隨者清單

原因是排序 createdAt 的欄位是 Followings 或 Followers 的 createdAt (但那其實是 user 建立的時間，不是 followship 建立的時間)

已將排序 createdAt 的欄位，修正為 Followers.Followship.createdAt 或 Followings.Followship.createdAt

測試：

- 已通過 postman 測試 

P.S. 為了確保更動有效，postman 測試時有加上 createdAt (Followship.createdAt) 來確認時間有由新到舊排序，測試通過後已拿掉該欄位以符合 apiary 格式

Followers
![getFollowers(postman)](https://user-images.githubusercontent.com/78346513/134491453-f0413fb1-41be-4d3c-9a05-cc13cb7875ad.png)

Followings
![getFollowings(postman)](https://user-images.githubusercontent.com/78346513/134491444-63b14abc-a187-45c7-82f7-b8d9bea55600.png)


- 已通過自動化測試
![getFollowings(自動化測試)](https://user-images.githubusercontent.com/78346513/134491458-9f642a58-edd3-4913-a901-ba6a38b0409b.png)


