### PR TITLE
fix: Fix database group nonaggregated and /api/admin/users order by id

### DIFF
--- a/services/adminService.js
+++ b/services/adminService.js
@@ -24,7 +24,7 @@ const adminService = {
       group: ['user.id'],
       order: [
         [Sequelize.literal('tweetsCount'), 'DESC'],
-        ['createdAt', 'DESC']
+        ['id', 'ASC']
       ],
       attributes: [
         'id',

--- a/services/userService.js
+++ b/services/userService.js
@@ -226,7 +226,7 @@ const userService = {
         'introduction',
         'account'
       ],
-      group: ['User.id'],
+      group: ['User.id', 'Followers.Followship.createdAt'],
       order: [[Sequelize.col('Followers.Followship.createdAt'), 'DESC']]
     })
   },
@@ -257,7 +257,7 @@ const userService = {
         'introduction',
         'account'
       ],
-      group: ['User.id'],
+      group: ['User.id', 'Followings.Followship.createdAt'],
       order: [[Sequelize.col('Followings.Followship.createdAt'), 'DESC']]
     })
   },


### PR DESCRIPTION
新增:
- 修正group與order的範圍一致
- 更改/api/admiin/users的第二排序為id

自動化測試:
![image](https://user-images.githubusercontent.com/24835719/134496889-cefe461f-a962-47aa-b5bc-6597258bf690.png)
