### PR TITLE
fix: modify user.id to id in adminService.getUsers

### DIFF
--- a/services/adminService.js
+++ b/services/adminService.js
@@ -21,7 +21,7 @@ const adminService = {
         { model: Like, attributes: [] },
         { model: Tweet, attributes: [] }
       ],
-      group: ['user.id'],
+      group: ['id'],
       order: [
         [Sequelize.literal('tweetsCount'), 'DESC'],
         ['id', 'ASC']


### PR DESCRIPTION
修改：

- adminService.getUsers 的 group 欄位從 user.id 改為 id

測試：

- 已通過自動化測試


![自動化的getUsers](https://user-images.githubusercontent.com/78346513/134539880-9a9a0248-b465-4844-9a25-03b81bfb957a.png)

- 已通過 postman 測
![postman的getUsers](https://user-images.githubusercontent.com/78346513/134539889-691fd630-a827-4d76-83d8-366cc86305c0.png)
試