### PR TITLE
Feature/public room

### DIFF
--- a/socket/events/publicRooms.js
+++ b/socket/events/publicRooms.js
@@ -7,12 +7,12 @@ module.exports = (io, socket, publicUsers) => {
       const isUserExists = publicUsers
         .map((user) => user.id)
         .includes(socket.user.id)
-      
+
       // If user is already exists, joining room without announce
       if (isUserExists) {
         return socket.join('public')
       }
-      
+
       // If user is not exists, pushing to public user list
       isUserExists ? false : publicUsers.push(socket.user)
       console.log(publicUsers)
@@ -20,13 +20,13 @@ module.exports = (io, socket, publicUsers) => {
       // Join public room
       socket.join('public')
       console.log(socket.rooms)
-      
+
       // Send announce to other public room users
       socket.to('public').emit('announce', {
         publicUsers,
         message: `${name} joined`
       })
-      
+
       // Send welcome message to current user
       socket.emit('announce', {
         publicUsers,
@@ -55,9 +55,22 @@ module.exports = (io, socket, publicUsers) => {
 
   socket.on('leavePublicRoom', async () => {
     try {
+      // Check if the same user has multiple client connection
+      const sameUserCount = await io.sockets.adapter.rooms.get(
+        `user-${socket.user.id}`
+      )
+
+      if (sameUserCount.size > 1) {
+        return socket.leave('public')
+      }
+
       // Remove current user from public user list
       publicUsers.splice(publicUsers.indexOf(socket.user), 1)
-      
+
+      // Leave public room
+      socket.leave('public')
+      console.log(socket.rooms)
+
       // Send announce only if the public room still have remained users
       if (publicUsers.length) {
         return socket.to('public').emit('announce', {

--- a/socket/index.js
+++ b/socket/index.js
@@ -34,22 +34,30 @@ module.exports = (io) => {
         }
         console.log(reason)
       }
-
     })
 
-    socket.on('disconnect', (reason) => {
+    socket.on('disconnect', async (reason) => {
       console.log(reason)
-      // Check if user is still in public room user list
-      if (publicUsers.indexOf(user)) {
-        publicUsers.splice(publicUsers.indexOf(user), 1)
+      // Check if the same user has multiple client connection
+      const sameUserCount = await io.sockets.adapter.rooms.get(
+        `user-${socket.user.id}`
+      )
 
-        // Send announce only if the public room still have remained users
-        if (publicUsers.length) {
-          socket.broadcast.emit('announce', {
-            publicUsers,
-            message: `${user.name} leaved`
-          })
+      if ((sameUserCount.size = 1)) {
+        // Check if user is still in public room user list
+        if (publicUsers.indexOf(user)) {
+          publicUsers.splice(publicUsers.indexOf(user), 1)
+
+          // Send announce only if the public room still have remained users
+          if (publicUsers.length) {
+            socket.to('public').emit('announce', {
+              publicUsers,
+              message: `${user.name} leaved`
+            })
+          }
         }
+
+        socket.leave('public')
       }
 
       console.log(publicUsers)

--- a/socket/index.js
+++ b/socket/index.js
@@ -26,16 +26,6 @@ module.exports = (io) => {
     publicRooms(io, socket, publicUsers)
     privateRooms(io, socket)
 
-    // Happened before disconnect
-    socket.on('disconnecting', (reason) => {
-      for (const room of socket.rooms) {
-        if (room !== socket.id) {
-          socket.to(room).emit('user has left', socket.id)
-        }
-        console.log(reason)
-      }
-    })
-
     socket.on('disconnect', async (reason) => {
       console.log(reason)
       // Check if the same user has multiple client connection

--- a/socket/index.js
+++ b/socket/index.js
@@ -3,10 +3,10 @@ const publicRooms = require('./events/publicRooms')
 const subscribes = require('./events/subscribes')
 const privateRooms = require('./events/privateRooms')
 
-module.exports = (io) => {
-  // Store current public users' list
-  const publicUsers = []
+// Store current public users' list
+const publicUsers = []
 
+module.exports = (io) => {
   io.use(socketAuthenticated).on('connection', (socket) => {
     // io.of("/").sockets and io.engine.clientsCount may be equal
     const clientsCount = io.engine.clientsCount


### PR DESCRIPTION
新增：

- 重構 index.js (disconnect 事件) 與 publicRooms.js (leavePublicRoom 事件)，以應對同一個使用者開啟多個分頁的情況

( 如 user 開啟多個分頁，server 端會在最後一個 client 連線中斷時，才將該 user 從 publicUsers 陣列移除 )

- 將 publicUsers 移至 exports 外，以防重置

- 移除 disconnecting 事件，因為目前公開聊天室的邏輯可以靠 disconnect 完成，以防混淆

測試：

- 已通過自動化測試

![publicRoom(自動化測試)](https://user-images.githubusercontent.com/78346513/134667823-6915fa89-98de-4c3e-aed7-c3765f165db8.png)

- POSTMAN 測試

1. user 5 自身加入公開聊天室
![publicRoom(user5加入公開聊天室)](https://user-images.githubusercontent.com/78346513/134667710-7ee5f1bd-79fb-4543-ab62-09a8f144793c.png)

2. 在公開聊天室的 user 1 收到 user 5 加入的訊息

![publicRoom(user5加入公開聊天室(他人視角))](https://user-images.githubusercontent.com/78346513/134667786-fe53ed4e-9b44-4173-8115-d52a15b6f83c.png)

3. 在公開聊天室的 user 1 收到 user 5 離開的訊息
![publicRoom(user5離開公開聊天室(user1視角))](https://user-images.githubusercontent.com/78346513/134667814-8b423d5f-b98f-4b8c-a8ff-cbbd2f1b3d22.png)


