### PR TITLE
Feature/public room

### DIFF
--- a/socket/events/publicRooms.js
+++ b/socket/events/publicRooms.js
@@ -44,18 +44,18 @@ module.exports = (io, socket, publicUsers) => {
     try {
       // Add public room id = 5
       msg.RoomId = 5
-      console.log(msg)
 
       // Save message to database
-      const message = await messageService.postMessage(msg).toJSON()
+      const message = await messageService.postMessage(msg)
       
       // Handle response data
       const data = {
         userId: socket.user.id,
         content: msg.content,
         avatar: socket.user.avatar,
-        createdAt: message.createdAt
+        createdAt: message.dataValues.createdAt
       }
+
       return io.in('public').emit('publicMessage', data)
     } catch (error) {
       return socket.emit('error', {

--- a/socket/events/publicRooms.js
+++ b/socket/events/publicRooms.js
@@ -42,9 +42,21 @@ module.exports = (io, socket, publicUsers) => {
 
   socket.on('publicMessage', async (msg) => {
     try {
-      // TODO: add messageService.postMessage({UserId,RoomID = 5 ,content})
-      await messageService.postMessage(msg)
-      return io.in('public').emit('publicMessage', msg)
+      // Add public room id = 5
+      msg.RoomId = 5
+      console.log(msg)
+
+      // Save message to database
+      const message = await messageService.postMessage(msg).toJSON()
+      
+      // Handle response data
+      const data = {
+        userId: socket.user.id,
+        content: msg.content,
+        avatar: socket.user.avatar,
+        createdAt: message.createdAt
+      }
+      return io.in('public').emit('publicMessage', data)
     } catch (error) {
       return socket.emit('error', {
         status: error.name,


### PR DESCRIPTION
修改：

- 調整 publicMessage event 的處理邏輯，讓回傳格式符合前端的需求 { UserId, content, avatar, createdAt }

測試：

- 已通過自動化測試

![publicMessage(自動化測試)](https://user-images.githubusercontent.com/78346513/134696617-96f7a1bc-a51a-45f9-a474-f875850b4cf0.png)


- 已通過 postman 測試

測試方式

1. 開啟三個連線 (user5, user1, user1)
2. 三個連線加入公開聊天室
3. 使用其中一個 user1 連線發出 publicMessage
4. 夾帶訊息為 { "UserId": 69, "content": "有聽到我說話嗎，那邊的 user5" }


- user1 (分頁1 發出訊息，也有收到發出自己的訊息)

![publicMessage(user1分頁2發出訊息)](https://user-images.githubusercontent.com/78346513/134696374-59163e59-0907-40f3-9373-7ebaa9208569.png)

- user1 (分頁2 有收到分頁 1 發出的訊息)

![publicMessage(user1分頁1收到訊息)](https://user-images.githubusercontent.com/78346513/134696391-878899ca-419b-426f-b475-a355b3710d9a.png)

- user5 (有收到 user1 分頁1 發出的訊息)

![publicMessage(user5收到訊息)](https://user-images.githubusercontent.com/78346513/134696405-a45db21b-c838-464c-8f80-bde7ef83d57c.png)


- 資料庫有正確儲存訊息

![publicMessage(u資料庫有正確儲存訊息)](https://user-images.githubusercontent.com/78346513/134696477-79f4b538-dc41-42cd-9877-a7613649d680.png)

