### PR TITLE
fix: remove user from public user list correctly when user disconnect

### DIFF
--- a/socket/events/publicRooms.js
+++ b/socket/events/publicRooms.js
@@ -59,10 +59,13 @@ module.exports = (io, socket, publicUsers) => {
 
       // Handle response data
       const data = {
-        userId: socket.user.id,
+        RoomId: msg.RoomId,
+        User: socket.user,
+        UserId: socket.user.id,
         content: msg.content,
-        avatar: socket.user.avatar,
-        createdAt: message.dataValues.createdAt
+        createdAt: message.dataValues.createdAt,
+        id: message.dataValues.id,
+        updatedAt: message.dataValues.updatedAt
       }
 
       return io.in('public').emit('publicMessage', data)

--- a/socket/events/publicRooms.js
+++ b/socket/events/publicRooms.js
@@ -15,7 +15,10 @@ module.exports = (io, socket, publicUsers) => {
       // If user is already exists, joining room without announce
       if (isUserExists) {
         console.log(publicUsers)
-        return socket.join('public')
+
+        socket.join('public')
+        // Update new publicUsers to client side
+        return io.to('public').emit('publicUsers', publicUsers)
       }
 
       // If user is not exists, pushing to public user list
@@ -28,15 +31,16 @@ module.exports = (io, socket, publicUsers) => {
 
       // Send announce to other public room users
       socket.to('public').emit('announce', {
-        publicUsers,
         message: `${name} joined`
       })
 
       // Send welcome message to current user
       socket.emit('announce', {
-        publicUsers,
         message: `Welcome, ${name}!`
       })
+
+      // Update new publicUsers to client side
+      io.to('public').emit('publicUsers', publicUsers)
     } catch (error) {
       return socket.emit('error', {
         status: error.name,
@@ -94,14 +98,18 @@ module.exports = (io, socket, publicUsers) => {
 
         // Send announce only if the public room still have remained users
         if (publicUsers.length) {
-          return socket.to('public').emit('announce', {
-            publicUsers,
+          socket.to('public').emit('announce', {
             message: `${name} leaved`
           })
         }
+
+        // Update new publicUsers to client side
+        return io.to('public').emit('publicUsers', publicUsers)
       }
 
-      return socket.leave('public')
+      socket.leave('public')
+      // Update new publicUsers to client side
+      return io.to('public').emit('publicUsers', publicUsers)
     } catch (error) {
       return socket.emit('error', {
         status: error.name,

--- a/socket/events/publicRooms.js
+++ b/socket/events/publicRooms.js
@@ -30,12 +30,12 @@ module.exports = (io, socket, publicUsers) => {
 
         // Send announce to other public room users
         socket.to('public').emit('announce', {
-          message: `${name} joined`
+          content: `${name} joined`
         })
 
         // Send welcome message to current user
         socket.emit('announce', {
-          message: `Welcome, ${name}!`
+          content: `Welcome, ${name}!`
         })
 
         // Update new publicUsers to client side
@@ -99,7 +99,7 @@ module.exports = (io, socket, publicUsers) => {
         // Send announce only if the public room still have remained users
         if (publicUsers.length) {
           socket.to('public').emit('announce', {
-            message: `${name} leaved`
+            content: `${name} leaved`
           })
         }
 

--- a/socket/events/publicRooms.js
+++ b/socket/events/publicRooms.js
@@ -19,28 +19,28 @@ module.exports = (io, socket, publicUsers) => {
         socket.join('public')
         // Update new publicUsers to client side
         return io.to('public').emit('publicUsers', publicUsers)
+      } else {
+        // If user is not exists, pushing to public user list
+        publicUsers.push(socket.user)
+        console.log(publicUsers)
+
+        // Join public room
+        socket.join('public')
+        console.log(socket.rooms)
+
+        // Send announce to other public room users
+        socket.to('public').emit('announce', {
+          message: `${name} joined`
+        })
+
+        // Send welcome message to current user
+        socket.emit('announce', {
+          message: `Welcome, ${name}!`
+        })
+
+        // Update new publicUsers to client side
+        io.to('public').emit('publicUsers', publicUsers)
       }
-
-      // If user is not exists, pushing to public user list
-      isUserExists ? false : publicUsers.push(socket.user)
-      console.log(publicUsers)
-
-      // Join public room
-      socket.join('public')
-      console.log(socket.rooms)
-
-      // Send announce to other public room users
-      socket.to('public').emit('announce', {
-        message: `${name} joined`
-      })
-
-      // Send welcome message to current user
-      socket.emit('announce', {
-        message: `Welcome, ${name}!`
-      })
-
-      // Update new publicUsers to client side
-      io.to('public').emit('publicUsers', publicUsers)
     } catch (error) {
       return socket.emit('error', {
         status: error.name,

--- a/socket/events/publicRooms.js
+++ b/socket/events/publicRooms.js
@@ -8,8 +8,13 @@ module.exports = (io, socket, publicUsers) => {
         .map((user) => user.id)
         .includes(socket.user.id)
 
+      console.log(
+        `${socket.user.name} is already in publicUsers array: ${isUserExists}`
+      )
+
       // If user is already exists, joining room without announce
       if (isUserExists) {
+        console.log(publicUsers)
         return socket.join('public')
       }
 
@@ -47,7 +52,7 @@ module.exports = (io, socket, publicUsers) => {
 
       // Save message to database
       const message = await messageService.postMessage(msg)
-      
+
       // Handle response data
       const data = {
         userId: socket.user.id,
@@ -68,28 +73,35 @@ module.exports = (io, socket, publicUsers) => {
   socket.on('leavePublicRoom', async () => {
     try {
       // Check if the same user has multiple client connection
-      const sameUserCount = await io.sockets.adapter.rooms.get(
-        `user-${socket.user.id}`
-      )
+      const sameUserCount = await await io
+        .in(`user-${socket.user.id}`)
+        .allSockets()
+      console.log(sameUserCount)
 
-      if (sameUserCount.size > 1) {
-        return socket.leave('public')
+      console.log(`=====${sameUserCount.size}======`)
+
+      // If current user is the last client connection of the same user
+      if (sameUserCount.size === 1) {
+        // Remove current user from public user list
+        const removedUserIndex = publicUsers.findIndex(
+          (user) => user.id === socket.user.id
+        )
+        publicUsers.splice(removedUserIndex, 1)
+
+        // Leave public room
+        socket.leave('public')
+        console.log(socket.rooms)
+
+        // Send announce only if the public room still have remained users
+        if (publicUsers.length) {
+          return socket.to('public').emit('announce', {
+            publicUsers,
+            message: `${name} leaved`
+          })
+        }
       }
 
-      // Remove current user from public user list
-      publicUsers.splice(publicUsers.indexOf(socket.user), 1)
-
-      // Leave public room
-      socket.leave('public')
-      console.log(socket.rooms)
-
-      // Send announce only if the public room still have remained users
-      if (publicUsers.length) {
-        return socket.to('public').emit('announce', {
-          publicUsers,
-          message: `${name} leaved`
-        })
-      }
+      return socket.leave('public')
     } catch (error) {
       return socket.emit('error', {
         status: error.name,

--- a/socket/index.js
+++ b/socket/index.js
@@ -29,14 +29,18 @@ module.exports = (io) => {
     socket.on('disconnect', async (reason) => {
       console.log(reason)
       // Check if the same user has multiple client connection
-      const sameUserCount = await io.sockets.adapter.rooms.get(
-        `user-${socket.user.id}`
-      )
+      const sameUserCount = await io.in(`user-${socket.user.id}`).allSockets()
 
-      if ((sameUserCount.size = 1)) {
+      console.log(`=====${sameUserCount.size}======`)
+      if (sameUserCount.size === 0) {
         // Check if user is still in public room user list
-        if (publicUsers.indexOf(user)) {
-          publicUsers.splice(publicUsers.indexOf(user), 1)
+        const removedUserIndex = publicUsers.findIndex(
+          (user) => user.id === socket.user.id
+        )
+        console.log(removedUserIndex)
+
+        if (removedUserIndex !== -1) {
+          publicUsers.splice(removedUserIndex, 1)
 
           // Send announce only if the public room still have remained users
           if (publicUsers.length) {

--- a/socket/index.js
+++ b/socket/index.js
@@ -45,15 +45,18 @@ module.exports = (io) => {
           // Send announce only if the public room still have remained users
           if (publicUsers.length) {
             socket.to('public').emit('announce', {
-              publicUsers,
               message: `${user.name} leaved`
             })
           }
+
+          // Update new publicUsers to client side
+          io.to('public').emit('publicUsers', publicUsers)
         }
 
         socket.leave('public')
       }
-
+      // Update new publicUsers to client side
+      io.to('public').emit('publicUsers', publicUsers)
       console.log(publicUsers)
     })
   })

--- a/socket/index.js
+++ b/socket/index.js
@@ -45,7 +45,7 @@ module.exports = (io) => {
           // Send announce only if the public room still have remained users
           if (publicUsers.length) {
             socket.to('public').emit('announce', {
-              message: `${user.name} leaved`
+              content: `${user.name} leaved`
             })
           }
 


### PR DESCRIPTION
修改：

1. 共同修改處

- 改由 io.in(`user${user.id}`).allSockets 取得當前使用者的 client 端連線數量，以修正上一版的方式會得到 undefined 的錯誤
- 改由 findIndex 的方式去搜尋 publicUsers 陣列中是否有物件的 id 等於 socket.user.id ，並回傳 index 值 (若無則回傳 -1) ，以避免 JS 的物件無法比較的問題
- 新增多項 console.log() 去顯示資訊，方便後續 debug，待提交挑戰功能前再移除

2. leavePublicRoom 相關

- 如果當前使用者只有一個 client 端連線，則移除出 publicUsers 陣列、離開 public room 與廣播離開訊息
- 如果當前使用者多於一個 client 端連線，則只有離開 public room，不移出 publicUsers 陣列與廣播離開訊息

3. disconnect 相關

- 如果當前使用者只有一個分頁，則離線事件中 sameUserCount 會等於 0
- sameUserCount 等於 0 時，會將使用者移除 publicUsers 陣列，離開 public room 與廣播離開訊息
- sameUserCount 不等於 0 時，只會離開 public room


測試：

- 已通過自動化測試


![user1(自動化測試)](https://user-images.githubusercontent.com/78346513/134732047-d597d355-079f-43d3-8b30-d03c3be8b03a.png)

- 已通過 POSTMAN 與 server 端測試

測試方式：

1. 三個 client 端連線，有 user5, user1, user1
2. 三個 client 端加入公開聊天室
3. 三個 client 端先後離線

1. user1 離線，公開聊天室仍有另一名 user1, user5 ( sameUserCount 為 1，publicUsers 仍有 user1, user5 )
![user1(user分頁1 斷線，仍還有分頁2)](https://user-images.githubusercontent.com/78346513/134730893-c513c7dd-e6b1-4a85-90e7-66d2ff651925.png)

2-1. 另一個 user1 離線，公開聊天室仍有 user5 ( sameUserCount 為 0， findIndex 為 1，publicUsers 剩 user5 )
![user1(user分頁2 斷線，已無分頁1)](https://user-images.githubusercontent.com/78346513/134731260-c28e8264-0449-49ff-98fa-10230911af7c.png)

2-2 user5 可收到 user1 離開的 announce ， publicUsers 剩 user5
![user1(user分頁2 斷線，user5 可收到離開訊息)](https://user-images.githubusercontent.com/78346513/134731288-0a9fa7f3-7125-4e92-8e3e-8a31406bef64.png)

3. user 5 斷線 (sameUserCount 為 0， findIndex 為 0，publicUsers 已清空)
![user1(user 5 斷線，publicUsers已清除)](https://user-images.githubusercontent.com/78346513/134731366-2163915b-eaa1-4c51-b4a9-c9213c02b7ec.png)


