### PR TITLE
Feature/socket message service

### DIFF
--- a/models/message.js
+++ b/models/message.js
@@ -11,7 +11,8 @@ module.exports = (sequelize, DataTypes) => {
     {
       content: DataTypes.STRING,
       UserId: DataTypes.INTEGER,
-      RoomId: DataTypes.INTEGER
+      RoomId: DataTypes.INTEGER,
+      isRead: DataTypes.BOOLEAN
     },
     {
       sequelize,

--- a/services/messageService.js
+++ b/services/messageService.js
@@ -135,6 +135,24 @@ const messageService = {
         ]
       ]
     })
+  },
+
+  putMessageIsReadStatus: async (RoomId, currentUserId) => {
+    if (!RoomId) {
+      throw new ApiError(
+        'getUnreadMessageCountError',
+        401,
+        'The RoomId cannot be blank'
+      )
+    }
+    return await Message.update(
+      { isRead: true },
+      {
+        where: {
+          [Op.and]: [{ UserId: currentUserId }, { RoomId: RoomId }]
+        }
+      }
+    )
   }
 }
 

--- a/services/messageService.js
+++ b/services/messageService.js
@@ -113,6 +113,28 @@ const messageService = {
       { RoomId, UserId: currentUserId },
       { RoomId, UserId: targetUserId }
     ])
+  },
+
+  getUnreadMessageCount: async (currentUserId) => {
+    return await User.findOne({
+      where: { id: currentUserId },
+      include: [{ model: Message, attributes: [] }],
+      attributes: [
+        ['id', 'UserId'],
+        [
+          Sequelize.literal(
+            `(SELECT COUNT(*) FROM Messages WHERE isRead = 0 AND RoomId = 5 AND UserId = ${currentUserId})`
+          ),
+          'PublicUnreadCount'
+        ],
+        [
+          Sequelize.literal(
+            `(SELECT COUNT(*) FROM Messages WHERE isRead = 0 AND RoomId != 5 AND UserId = ${currentUserId})`
+          ),
+          'PrivateUnreadCount'
+        ]
+      ]
+    })
   }
 }
 

--- a/services/messageService.js
+++ b/services/messageService.js
@@ -10,8 +10,8 @@ const ApiError = require('../utils/customError')
 
 const messageService = {
   postMessage: async (message) => {
-    const { UserId, RoomId, content } = message
-
+    let { UserId, RoomId, content, isRead } = message
+    isRead ? true : false
     // Check message format with Joi schema
     const { error } = messageSchema.validate(message, { abortEarly: false })
 
@@ -26,7 +26,8 @@ const messageService = {
     return await Message.create({
       UserId,
       RoomId,
-      content
+      content,
+      isRead
     })
   },
 

--- a/services/messageService.js
+++ b/services/messageService.js
@@ -115,25 +115,17 @@ const messageService = {
     ])
   },
 
-  getUnreadMessageCount: async (currentUserId) => {
-    return await User.findOne({
-      where: { id: currentUserId },
-      include: [{ model: Message, attributes: [] }],
-      attributes: [
-        ['id', 'UserId'],
-        [
+  getPrivateUnreadMessageCount: async (currentUserId) => {
+    return await Message.count({
+      where: {
+        UserId: { [Op.not]: currentUserId },
+        RoomId: [
           Sequelize.literal(
-            `(SELECT COUNT(*) FROM Messages WHERE isRead = 0 AND RoomId = 5 AND UserId = ${currentUserId})`
-          ),
-          'PublicUnreadCount'
+            `SELECT name FROM Rooms WHERE name LIKE '%${currentUserId}%'`
+          )
         ],
-        [
-          Sequelize.literal(
-            `(SELECT COUNT(*) FROM Messages WHERE isRead = 0 AND RoomId != 5 AND UserId = ${currentUserId})`
-          ),
-          'PrivateUnreadCount'
-        ]
-      ]
+        isRead: false
+      }
     })
   },
 
@@ -148,9 +140,7 @@ const messageService = {
     return await Message.update(
       { isRead: true },
       {
-        where: {
-          [Op.and]: [{ UserId: currentUserId }, { RoomId: RoomId }]
-        }
+        where: { UserId: { [Op.not]: currentUserId }, RoomId }
       }
     )
   }

--- a/utils/validator.js
+++ b/utils/validator.js
@@ -77,6 +77,9 @@ const memberSchema = Joi.object({
   }),
   RoomId: Joi.required().messages({
     'any.required': 'The RoomId cannot be blank'
+  }),
+  isRead: Joi.required().messages({
+    'any.required': 'The isRead cannot be blank'
   })
 })
 


### PR DESCRIPTION
新增:
- getUnreadMessageCount: 計算當前使用者的公開與私人未讀訊息數
- putMessageIsReadStatus: 更新當前使用者指定Room的訊息isRead = true
- postMessage 新增isRead 參數，預設為false。

自動化測試:
 ![image](https://user-images.githubusercontent.com/24835719/134771410-d4a41559-050c-4222-be2a-de44ab45cc39.png) 新增

Postman 測試:

- getUnreadMessageCount

目前UserId=15 , 其中有1筆未讀的Public 、0筆未讀的Private

![Screen Shot 2021-09-25 at 8 08 46 PM](https://user-images.githubusercontent.com/24835719/134771439-5cd5248a-6a83-434b-8034-603c8786e512.png)

![Screen Shot 2021-09-25 at 8 08 31 PM](https://user-images.githubusercontent.com/24835719/134771460-fa478c94-8458-4395-806d-e131df8b6910.png)

- putMessageIsReadStatus
目前UserId=15 的RoomId=15 , 有1筆未讀的訊息。
![Screen Shot 2021-09-25 at 8 06 48 PM](https://user-images.githubusercontent.com/24835719/134771501-2dc9b7d0-e4e6-46d0-9bd9-1d1432b3d295.png)

![Screen Shot 2021-09-25 at 8 07 03 PM](https://user-images.githubusercontent.com/24835719/134771503-8fb11556-b945-4028-8b67-ef1f68fcb627.png)

![Screen Shot 2021-09-25 at 8 07 13 PM](https://user-images.githubusercontent.com/24835719/134771507-6beb0b00-6b3d-4383-bf6a-a86fe89c3a39.png)

- postMessage
![image](https://user-images.githubusercontent.com/24835719/134771584-94b5b952-114e-4201-81b9-68e77e6d2aed.png)

![image](https://user-images.githubusercontent.com/24835719/134771589-b6ae1af9-53f5-4170-bbf1-385b272dfb83.png)



