### PR TITLE
Hotfix

### DIFF
--- a/socket/events/privateRooms.js
+++ b/socket/events/privateRooms.js
@@ -28,19 +28,24 @@ module.exports = (io, socket) => {
         targetUserId,
         currentUserId
       )
-      
+
       // Set RoomId and roomName due to new private room or existed private room
       privateRoom = privateRoom.toJSON()
       let RoomId
       let roomName
       console.log(privateRoom)
-
+      
+      // private room is already exists
       if (privateRoom.Room) {
         RoomId = privateRoom.RoomId
         roomName = privateRoom.Room.name
+      // a new private room
       } else {
         RoomId = privateRoom.id
         roomName = privateRoom.name
+        io.to(`user-${targetUserId}`).emit('newPrivateRoom', {
+          message: `New private room: ${roomName} is created by ${socket.user.name}`
+        })
       }
 
       // Join private room
@@ -117,7 +122,7 @@ module.exports = (io, socket) => {
       console.log(`currentUser: ${currentUserId}, targetUser: ${targetUserId}`)
       const privateUnreadMessageCount =
         await messageService.getPrivateUnreadMessageCount(targetUserId)
-      // TODO: const unread = await messageService.checkUnread(targetUserId)
+    
       io.to(`user-${targetUserId}`).emit('unReadMessage', {
         privateUnreadMessageCount
       })

--- a/socket/events/privateRooms.js
+++ b/socket/events/privateRooms.js
@@ -24,20 +24,33 @@ module.exports = (io, socket) => {
     try {
       // Find or create if private room can't be found
       const { targetUserId, currentUserId } = msg
-      const privateRoom = await messageService.postPrivateRoom(
+      let privateRoom = await messageService.postPrivateRoom(
         targetUserId,
         currentUserId
       )
-      const RoomId = privateRoom.Room.dataValues.id
+      
+      // Set RoomId and roomName due to new private room or existed private room
+      privateRoom = privateRoom.toJSON()
+      let RoomId
+      let roomName
+      console.log(privateRoom)
+
+      if (privateRoom.Room) {
+        RoomId = privateRoom.RoomId
+        roomName = privateRoom.Room.name
+      } else {
+        RoomId = privateRoom.id
+        roomName = privateRoom.name
+      }
 
       // Join private room
-      socket.join(privateRoom.Room.dataValues.name)
+      socket.join(roomName)
 
       // Send RoomId back to client
       callback({ RoomId })
 
       // Set private room name to socket.user
-      socket.user.privateRoom = privateRoom.Room.dataValues.name
+      socket.user.privateRoom = roomName
 
       console.log(socket.user)
       console.log(socket.rooms)

--- a/socket/index.js
+++ b/socket/index.js
@@ -17,9 +17,10 @@ module.exports = (io) => {
     )
 
     // Check if current user has unread messages
-      const privateUnreadMessageCount =
-        await messageService.getPrivateUnreadMessageCount(user.id)
-
+    const privateUnreadMessageCount =
+      await messageService.getPrivateUnreadMessageCount(user.id)
+    socket.emit('unReadMessage', { privateUnreadMessageCount })
+    
     // Join user room to act as same user with multiple browser tabs
     socket.join(`user-${user.id}`)
 


### PR DESCRIPTION
修改：

- joinPrivateRoom 事件新增 if 條件，依據回傳的 privateRoom 是已存在的房間，或是新建立的房間，來取得 RoomId, roomName 值

- connect 事件新增觸發 unReadMessage 事件，讓使用者每次登入都可以取得未讀訊息資訊

測試：

- 已通過自動化測試
![privateRoom(新增unRead登入事件的自動化測試)](https://user-images.githubusercontent.com/78346513/134784292-988707d0-7628-45f6-bf16-32f38fe21b0a.png)

- 已通過 POSTMAN 測試

1. 登入即接收 unReadMessage 事件取得未讀訊息
![privateRoom(登入即送未讀通知)](https://user-images.githubusercontent.com/78346513/134784300-8fce6c22-d7cd-4aaf-82dc-f046593e5e86.png)

2.  建立新房間 (id 45 與 id 69 ，有正確取得值並回傳 RoomId )
![privateRoom(建立新房間45-69)](https://user-images.githubusercontent.com/78346513/134784311-93546abc-c27d-4847-af99-11218f0f73ef.png)

3. 存取已有的房間 (id 55 與 id 69，有正確取得值並回傳 RoomId)
![privateRoom(進入已存在房間55-69)](https://user-images.githubusercontent.com/78346513/134784312-e738f925-fe7b-4b12-af2b-38aa367bed8c.png)


