### PR TITLE
Feature/socket message service

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -39,6 +39,26 @@ const messageController = {
     } catch (error) {
       next(error)
     }
+  },
+
+  getLatestMessage: async (req, res, next) => {
+    try {
+      const currentUserId = helpers.getUser(req).id
+
+      if (!currentUserId) {
+        throw new ApiError(
+          'getLatestMessageError',
+          401,
+          'The currentUserId cannot be blank'
+        )
+      }
+      const latestMessages = await messageService.getLatestMessage(
+        currentUserId
+      )
+      return res.status(200).json(latestMessages)
+    } catch (error) {
+      next(error)
+    }
   }
 }
 

--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -41,7 +41,7 @@ const messageController = {
     }
   },
 
-  getLatestMessage: async (req, res, next) => {
+  getLatestMessages: async (req, res, next) => {
     try {
       const currentUserId = helpers.getUser(req).id
 
@@ -52,7 +52,7 @@ const messageController = {
           'The currentUserId cannot be blank'
         )
       }
-      const latestMessages = await messageService.getLatestMessage(
+      const latestMessages = await messageService.getLatestMessages(
         currentUserId
       )
       return res.status(200).json(latestMessages)

--- a/routes/modules/messages.js
+++ b/routes/modules/messages.js
@@ -2,6 +2,7 @@ const express = require('express')
 const router = express.Router()
 const messageController = require('../../controllers/messageController')
 
+router.get('/latest_messages', messageController.getLatestMessages)
 router.get('/private', messageController.getPrivateRooms)
 router.get('/:RoomId', messageController.getMessages)
 

--- a/services/messageService.js
+++ b/services/messageService.js
@@ -123,9 +123,9 @@ const messageService = {
   },
 
   // FIXME: Directly through Sequlize, no further processing is required.
-  getLatestMessage: async (currentUserId) => {
+  getLatestMessages: async (currentUserId) => {
     const set = new Set()
-    const messgaes = await Message.findAll({
+    const messages = await Message.findAll({
       raw: true,
       nest: true,
       include: [
@@ -156,8 +156,8 @@ const messageService = {
       order: [['createdAt', 'DESC']]
     })
 
-    const latestMessages = messgaes.filter((messgae) =>
-      set.has(messgae.UserId) ? false : set.add(messgae.UserId)
+    const latestMessages = messages.filter((message) =>
+      set.has(message.UserId) ? false : set.add(message.UserId)
     )
 
     return latestMessages

--- a/services/messageService.js
+++ b/services/messageService.js
@@ -122,20 +122,45 @@ const messageService = {
     })
   },
 
-  putMessageIsReadStatus: async (RoomId, currentUserId) => {
-    if (!RoomId) {
-      throw new ApiError(
-        'getUnreadMessageCountError',
-        401,
-        'The RoomId cannot be blank'
-      )
-    }
-    return await Message.update(
-      { isRead: true },
-      {
-        where: { UserId: { [Op.not]: currentUserId }, RoomId }
-      }
+  // FIXME: Directly through Sequlize, no further processing is required.
+  getLatestMessage: async (currentUserId) => {
+    const set = new Set()
+    const messgaes = await Message.findAll({
+      raw: true,
+      nest: true,
+      include: [
+        {
+          model: Room,
+          where: {
+            name: { [Op.substring]: currentUserId }
+          },
+          order: [['createdAt', 'DESC']]
+        },
+        {
+          model: User,
+          attributes: ['id', 'avatar', 'name', 'account']
+        }
+      ],
+      where: {
+        UserId: { [Op.not]: currentUserId }
+      },
+      attributes: [
+        'id',
+        'createdAt',
+        'updatedAt',
+        'content',
+        'RoomId',
+        'UserId'
+      ],
+      group: ['id', 'RoomId'],
+      order: [['createdAt', 'DESC']]
+    })
+
+    const latestMessages = messgaes.filter((messgae) =>
+      set.has(messgae.UserId) ? false : set.add(messgae.UserId)
     )
+
+    return latestMessages
   }
 }
 


### PR DESCRIPTION
新增:
- GET /api/messages/latest_messages : 取得當前使用者所有私人聊天室列表的最新一筆訊息，並包含Room、User的資訊。

自動化測試:

![image](https://user-images.githubusercontent.com/24835719/134794055-90bf733b-b8eb-48bb-bd39-32409c905437.png)

Postman 測試:
當前使用者ID = 15 ， 目前有私人聊天室兩間，相對應的UserId為25、35、RoomId 為15、25
![image](https://user-images.githubusercontent.com/24835719/134794081-c584e879-8498-48a8-a313-e3eb1a253a17.png)

其中RoomId 15 且非當前使用者(15)的訊息有2筆  ，其中最後一筆的建立日期為2021-09-25 12:28:14 (id: 75)
其中RoomId 25 且非當前使用者(15)的訊息有2筆 ，其中最後一筆的建立日期為2021-09-25 17:30:15  (id: 95)

![image](https://user-images.githubusercontent.com/24835719/134794233-366147ac-249a-4e99-bb10-16762e5bab7a.png)


透過API 回傳:
![image](https://user-images.githubusercontent.com/24835719/134794195-9ec848f0-8055-4df5-b441-e52d8b8c1133.png)


