### PR TITLE
feat: Modify getLatestMessages to get all private room 's latest message

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -52,9 +52,20 @@ const messageController = {
           'The currentUserId cannot be blank'
         )
       }
+      const rooms = await messageService.getPrivateRooms(null, currentUserId)
       const latestMessages = await messageService.getLatestMessages(
         currentUserId
       )
+
+      latestMessages.forEach((message) => {
+        rooms.forEach((room) => {
+          if (room.RoomId === message.RoomId) {
+            message.User = room.User
+            message.Room = room.Room
+          }
+        })
+      })
+
       return res.status(200).json(latestMessages)
     } catch (error) {
       next(error)

--- a/services/messageService.js
+++ b/services/messageService.js
@@ -70,6 +70,8 @@ const messageService = {
       : { [Op.not]: currentUserId }
 
     return await Member.findAll({
+      raw: true,
+      nest: true,
       where: {
         UserId: queryOption,
         RoomId: [
@@ -131,6 +133,7 @@ const messageService = {
       include: [
         {
           model: Room,
+          attributes: [],
           where: {
             name: { [Op.substring]: currentUserId }
           },
@@ -138,26 +141,16 @@ const messageService = {
         },
         {
           model: User,
-          attributes: ['id', 'avatar', 'name', 'account']
+          attributes: []
         }
       ],
-      where: {
-        UserId: { [Op.not]: currentUserId }
-      },
-      attributes: [
-        'id',
-        'createdAt',
-        'updatedAt',
-        'content',
-        'RoomId',
-        'UserId'
-      ],
-      group: ['id', 'RoomId'],
+      attributes: ['id', 'createdAt', 'content', 'RoomId'],
+      group: ['id'],
       order: [['createdAt', 'DESC']]
     })
 
     const latestMessages = messages.filter((message) =>
-      set.has(message.UserId) ? false : set.add(message.UserId)
+      set.has(message.RoomId) ? false : set.add(message.RoomId)
     )
 
     return latestMessages


### PR DESCRIPTION
修正:
- 將getLatestMessages 的回傳值與getPrivateRooms進行整合
- 調正getLatestMessages 不會排除currentUser 回傳都是當前Room的最新訊息。

備註:
用了兩個forEach 覺得想當不好，只能在未來再進行修正了。

自動化測試:
![image](https://user-images.githubusercontent.com/24835719/134796808-61a2c875-10b6-4964-a91b-126759121f10.png)

Postman測試:
目前使用者ID = 15 , 其各別與User 25 、35 有兩個Private Room: 15 、25
![image](https://user-images.githubusercontent.com/24835719/134796873-180a38d2-1ec0-40d6-bd59-90c40df7d2e5.png)

然後Room: 15 、25 各有兩筆最新訊息，分別為115與125
![image](https://user-images.githubusercontent.com/24835719/134797423-357e7115-32f4-406c-a284-811b30a47417.png)

![image](https://user-images.githubusercontent.com/24835719/134797410-deb666b7-a4db-479d-a1f9-fa0e6b0bc5c1.png)





