### PR TITLE
Hotfix

### DIFF
--- a/services/messageService.js
+++ b/services/messageService.js
@@ -124,6 +124,22 @@ const messageService = {
     })
   },
 
+  putMessageIsReadStatus: async (RoomId, currentUserId) => {
+    if (!RoomId) {
+      throw new ApiError(
+        'getUnreadMessageCountError',
+        401,
+        'The RoomId cannot be blank'
+      )
+    }
+    return await Message.update(
+      { isRead: true },
+      {
+        where: { UserId: { [Op.not]: currentUserId }, RoomId }
+      }
+    )
+  },
+
   // FIXME: Directly through Sequlize, no further processing is required.
   getLatestMessages: async (currentUserId) => {
     const set = new Set()

--- a/socket/events/privateRooms.js
+++ b/socket/events/privateRooms.js
@@ -28,12 +28,14 @@ module.exports = (io, socket) => {
         targetUserId,
         currentUserId
       )
+      
+      console.log('======================================================')
+      console.log(privateRoom)
+      console.log('======================================================')
 
       // Set RoomId and roomName due to new private room or existed private room
-      privateRoom = privateRoom.toJSON()
       let RoomId
       let roomName
-      console.log(privateRoom)
       
       // private room is already exists
       if (privateRoom.Room) {
@@ -41,12 +43,14 @@ module.exports = (io, socket) => {
         roomName = privateRoom.Room.name
       // a new private room
       } else {
-        RoomId = privateRoom.id
-        roomName = privateRoom.name
+        RoomId = privateRoom.dataValues.id
+        roomName = privateRoom.dataValues.name
         io.to(`user-${targetUserId}`).emit('newPrivateRoom', {
           message: `New private room: ${roomName} is created by ${socket.user.name}`
         })
       }
+
+      console.log(roomName, RoomId)
 
       // Join private room
       socket.join(roomName)


### PR DESCRIPTION
修正：

1. 調整加入私聊房間事件時，從 getPrivateRooms 回傳值取得 roomName, RoomId 的路徑，以應對新回傳格式
2. 補上 messageService.putMessageIsReadStatus ，以修復更新未讀訊息狀態的功能

測試：

- 已通過自動化測試

![hotfix修正(自動化)](https://user-images.githubusercontent.com/78346513/134798438-c2dac22a-22cb-47d4-84f8-8218c19e8afd.png)

- 已通過 POSTMAN 測試

在補回 messageService.putMessageIsReadStatus 的情況下，分別測試建立新私聊房間與取得既有私聊房間

1. 新私聊房間，正常回傳 RoomId 與未讀通知事件，未報錯
![hotfix修正(補上service，無報錯)](https://user-images.githubusercontent.com/78346513/134798443-2da68dba-c902-4338-8a52-d84f8fe26a01.png)

2. 已存在房間，正常回傳 RoomId 與未讀通知事件，未報錯
![hotfix修正(加入已存在房間，正常)](https://user-images.githubusercontent.com/78346513/134798447-815203b3-1f49-4710-8200-bcd0e77ca183.png)

