### PR TITLE
Feature/public room

### DIFF
--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -49,7 +49,7 @@ const socketAuthenticated = (socket, next) => {
     }
     socket.user = await User.findByPk(decoded.id, {
       raw: true,
-      attributes: ['id', 'name', 'avatar', 'account', 'lastLogin']
+      attributes: ['id', 'name', 'avatar', 'account', 'lastJoinPublic']
     })
     return next()
   })

--- a/middlewares/auth.js
+++ b/middlewares/auth.js
@@ -49,7 +49,7 @@ const socketAuthenticated = (socket, next) => {
     }
     socket.user = await User.findByPk(decoded.id, {
       raw: true,
-      attributes: ['id', 'name', 'avatar', 'account']
+      attributes: ['id', 'name', 'avatar', 'account', 'lastLogin']
     })
     return next()
   })

--- a/migrations/20210926033357-add-lastLogin-to-user.js
+++ b/migrations/20210926033357-add-lastLogin-to-user.js
@@ -1,4 +1,4 @@
-'use strict';
+'use strict'
 
 module.exports = {
   up: async (queryInterface, Sequelize) => {
@@ -12,4 +12,4 @@ module.exports = {
   down: async (queryInterface, Sequelize) => {
     await queryInterface.removeColumn('Users', 'lastLogin')
   }
-};
+}

--- a/migrations/20210926033357-add-lastLogin-to-user.js
+++ b/migrations/20210926033357-add-lastLogin-to-user.js
@@ -1,0 +1,15 @@
+'use strict';
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.addColumn('Users', 'lastLogin', {
+      type: Sequelize.DATE,
+      allowNull: false,
+      defaultValue: new Date()
+    })
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.removeColumn('Users', 'lastLogin')
+  }
+};

--- a/migrations/20210926055956-rename-lastLogin-to-lastJoinPublic-in-user.js
+++ b/migrations/20210926055956-rename-lastLogin-to-lastJoinPublic-in-user.js
@@ -1,0 +1,11 @@
+'use strict'
+
+module.exports = {
+  up: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn('Users', 'lastLogin', 'lastJoinPublic')
+  },
+
+  down: async (queryInterface, Sequelize) => {
+    await queryInterface.renameColumn('Users', 'lastJoinPublic', 'lastLogin')
+  }
+}

--- a/models/user.js
+++ b/models/user.js
@@ -25,6 +25,10 @@ module.exports = (sequelize, DataTypes) => {
       cover: {
         type: DataTypes.STRING,
         defaultValue: 'https://i.imgur.com/1L2chcu.jpg'
+      },
+      lastLogin: {
+        type: DataTypes.DATE,
+        defaultValue: new Date()
       }
     },
     {}

--- a/models/user.js
+++ b/models/user.js
@@ -26,7 +26,7 @@ module.exports = (sequelize, DataTypes) => {
         type: DataTypes.STRING,
         defaultValue: 'https://i.imgur.com/1L2chcu.jpg'
       },
-      lastLogin: {
+      lastJoinPublic: {
         type: DataTypes.DATE,
         defaultValue: new Date()
       }

--- a/socket/events/publicRooms.js
+++ b/socket/events/publicRooms.js
@@ -14,12 +14,12 @@ module.exports = (io, socket, publicUsers) => {
       )
 
       // Update user's public unread message status
-      const updatedUser = await socketHelpers.updateUserLastLogin(
+      const updatedUser = await socketHelpers.updateUserLastJoinPublic(
         socket.user.id
       )
-      socket.user.lastLogin = updatedUser.dataValues.lastLogin
+      socket.user.lastJoinPublic = updatedUser.dataValues.lastJoinPublic
       const hasUnreadPublicMessage = await socketHelpers.hasUnreadPublicMessage(
-        socket.user.lastLogin
+        socket.user.lastJoinPublic
       )
       socket.emit('publicUnreadMessage', { hasUnreadPublicMessage })
 

--- a/socket/events/publicRooms.js
+++ b/socket/events/publicRooms.js
@@ -1,4 +1,5 @@
 const messageService = require('../../services/messageService')
+const socketHelpers = require('../../utils/socketHelpers')
 module.exports = (io, socket, publicUsers) => {
   const { name, id } = socket.user
   socket.on('joinPublicRoom', async () => {
@@ -11,6 +12,16 @@ module.exports = (io, socket, publicUsers) => {
       console.log(
         `${socket.user.name} is already in publicUsers array: ${isUserExists}`
       )
+
+      // Update user's public unread message status
+      const updatedUser = await socketHelpers.updateUserLastLogin(
+        socket.user.id
+      )
+      socket.user.lastLogin = updatedUser.dataValues.lastLogin
+      const hasUnreadPublicMessage = await socketHelpers.hasUnreadPublicMessage(
+        socket.user.lastLogin
+      )
+      socket.emit('publicUnreadMessage', { hasUnreadPublicMessage })
 
       // If user is already exists, joining room without announce
       if (isUserExists) {
@@ -70,6 +81,12 @@ module.exports = (io, socket, publicUsers) => {
         updatedAt: message.dataValues.updatedAt
       }
 
+      // Send unread notification to online users except public room users
+      io.except('public').emit('publicUnreadMessage', {
+        hasUnreadPublicMessage: true
+      })
+
+      // Send public message to public room users
       return io.in('public').emit('publicMessage', data)
     } catch (error) {
       console.log(error)

--- a/socket/index.js
+++ b/socket/index.js
@@ -24,7 +24,7 @@ module.exports = (io) => {
 
     // Check if current user has public unread messages
     const hasUnreadPublicMessage = await socketHelpers.hasUnreadPublicMessage(
-      socket.user.lastLogin
+      socket.user.lastJoinPublic
     )
     console.log(hasUnreadPublicMessage)
 
@@ -74,9 +74,6 @@ module.exports = (io) => {
       // Update new publicUsers to client side
       io.to('public').emit('publicUsers', publicUsers)
       console.log(publicUsers)
-
-      // Update user's last login time
-      await socketHelpers.updateUserLastLogin(socket.user.id)
     })
   })
 }

--- a/socket/index.js
+++ b/socket/index.js
@@ -16,10 +16,20 @@ module.exports = (io) => {
       ` ${user.name} connected and number of connections ${clientsCount}`
     )
 
-    // Check if current user has unread messages
+    // Check if current user has private unread messages
     const privateUnreadMessageCount =
       await messageService.getPrivateUnreadMessageCount(user.id)
     socket.emit('unReadMessage', { privateUnreadMessageCount })
+
+    // Check if current user has public unread messages
+    const publicMessages = await messageService.getMessages(5)
+    const lastMessagesCreatedAt = publicMessages[publicMessages.length - 1].createdAt
+    const hasUnreadPublicMessage = lastMessagesCreatedAt > socket.user.lastLogin
+    console.log(hasUnreadPublicMessage)
+
+    if (hasUnreadPublicMessage) {
+      socket.emit('publicUnreadMessage', { hasUnreadPublicMessage })
+    }
     
     // Join user room to act as same user with multiple browser tabs
     socket.join(`user-${user.id}`)

--- a/socket/index.js
+++ b/socket/index.js
@@ -3,6 +3,7 @@ const publicRooms = require('./events/publicRooms')
 const subscribes = require('./events/subscribes')
 const privateRooms = require('./events/privateRooms')
 const messageService = require('../services/messageService')
+const socketHelpers = require('../utils/socketHelpers')
 
 // Store current public users' list
 const publicUsers = []
@@ -22,9 +23,9 @@ module.exports = (io) => {
     socket.emit('unReadMessage', { privateUnreadMessageCount })
 
     // Check if current user has public unread messages
-    const publicMessages = await messageService.getMessages(5)
-    const lastMessagesCreatedAt = publicMessages[publicMessages.length - 1].createdAt
-    const hasUnreadPublicMessage = lastMessagesCreatedAt > socket.user.lastLogin
+    const hasUnreadPublicMessage = await socketHelpers.hasUnreadPublicMessage(
+      socket.user.lastLogin
+    )
     console.log(hasUnreadPublicMessage)
 
     if (hasUnreadPublicMessage) {

--- a/socket/index.js
+++ b/socket/index.js
@@ -75,6 +75,9 @@ module.exports = (io) => {
       // Update new publicUsers to client side
       io.to('public').emit('publicUsers', publicUsers)
       console.log(publicUsers)
+
+      // Update user's last login time
+      await socketHelpers.updateUserLastLogin(socket.user.id)
     })
   })
 }

--- a/socket/index.js
+++ b/socket/index.js
@@ -28,9 +28,8 @@ module.exports = (io) => {
     )
     console.log(hasUnreadPublicMessage)
 
-    if (hasUnreadPublicMessage) {
-      socket.emit('publicUnreadMessage', { hasUnreadPublicMessage })
-    }
+    socket.emit('publicUnreadMessage', { hasUnreadPublicMessage })
+    
     
     // Join user room to act as same user with multiple browser tabs
     socket.join(`user-${user.id}`)

--- a/utils/socketHelpers.js
+++ b/utils/socketHelpers.js
@@ -1,4 +1,5 @@
 const messageService = require('../services/messageService')
+const { User } = require('../models')
 
 const hasUnreadPublicMessage = async (lastLogin) => {
   const publicMessages = await messageService.getMessages(5)
@@ -7,4 +8,13 @@ const hasUnreadPublicMessage = async (lastLogin) => {
   return lastMessagesCreatedAt > lastLogin
 }
 
-module.exports = { hasUnreadPublicMessage }
+const updateUserLastLogin = async (currentUserId) => {
+  return await User.update(
+    {
+      lastLogin: new Date()
+    },
+    { where: { id: currentUserId } }
+  )
+}
+
+module.exports = { hasUnreadPublicMessage, updateUserLastLogin }

--- a/utils/socketHelpers.js
+++ b/utils/socketHelpers.js
@@ -8,15 +8,15 @@ const hasUnreadPublicMessage = async (lastLogin) => {
   return lastMessagesCreatedAt > lastLogin
 }
 
-const updateUserLastLogin = async (currentUserId) => {
+const updateUserLastJoinPublic = async (currentUserId) => {
   await User.update(
     {
-      lastLogin: new Date()
+      lastJoinPublic: new Date()
     },
     { where: { id: currentUserId } }
   )
 
-  return User.findByPk(currentUserId, { attributes: ['lastLogin'] })
+  return User.findByPk(currentUserId, { attributes: ['lastJoinPublic'] })
 }
 
-module.exports = { hasUnreadPublicMessage, updateUserLastLogin }
+module.exports = { hasUnreadPublicMessage, updateUserLastJoinPublic }

--- a/utils/socketHelpers.js
+++ b/utils/socketHelpers.js
@@ -9,12 +9,14 @@ const hasUnreadPublicMessage = async (lastLogin) => {
 }
 
 const updateUserLastLogin = async (currentUserId) => {
-  return await User.update(
+  await User.update(
     {
       lastLogin: new Date()
     },
     { where: { id: currentUserId } }
   )
+
+  return User.findByPk(currentUserId, { attributes: ['lastLogin'] })
 }
 
 module.exports = { hasUnreadPublicMessage, updateUserLastLogin }

--- a/utils/socketHelpers.js
+++ b/utils/socketHelpers.js
@@ -1,11 +1,11 @@
 const messageService = require('../services/messageService')
 const { User } = require('../models')
 
-const hasUnreadPublicMessage = async (lastLogin) => {
+const hasUnreadPublicMessage = async (lastJoinPublic) => {
   const publicMessages = await messageService.getMessages(5)
   const lastMessagesCreatedAt =
     publicMessages[publicMessages.length - 1].createdAt
-  return lastMessagesCreatedAt > lastLogin
+  return lastMessagesCreatedAt > lastJoinPublic
 }
 
 const updateUserLastJoinPublic = async (currentUserId) => {

--- a/utils/socketHelpers.js
+++ b/utils/socketHelpers.js
@@ -1,0 +1,10 @@
+const messageService = require('../services/messageService')
+
+const hasUnreadPublicMessage = async (lastLogin) => {
+  const publicMessages = await messageService.getMessages(5)
+  const lastMessagesCreatedAt =
+    publicMessages[publicMessages.length - 1].createdAt
+  return lastMessagesCreatedAt > lastLogin
+}
+
+module.exports = { hasUnreadPublicMessage }


### PR DESCRIPTION
**新增功能：公開聊天室未讀通知**

**新增列表：**

1. Users model 新增 lastJoinPublic 欄位，儲存使用者上一次加入公開聊天室的時間 
2. socket 驗證時，新增 lastJoinPublic 資料到 socket.user
3. 將取得公開訊息未讀通知與更新使用者 lastJoinPublic 的 function 抽出並放在 socketHelpers.js 
4.  新增 publicUnreadMessage 事件，回傳值為 { hasUnreadPublicMessage: true/false } ，true 表示有未讀訊息

**事件邏輯：**

登入

1. 每次 connect 取得當前公開聊天室最新訊息的 createdAt，並和使用者的 lastJoinPublic 比較
2. 觸發 publicUnreadMessage 事件，並依據 lastJoinPublic 和 createdAt 的比較結果回傳 true / false


加入公開聊天室

1. 每次 joinPublicRoom 時依據 socket.user.id 去更新當前使用者的 lastJoinPublic 時間
2. 觸發 publicUnreadMessage 事件，並依據 lastJoinPublic 和 createdAt 的比較結果回傳 true / false 
    (這邊理論上都會是 false，因為更新時間後立刻比較)

發出公開聊天室訊息

1. 任何使用者發出公聊訊息時，也要傳給所有不在公開聊天室，但還在線上的使用者公開訊息未讀通知

**測試：**

- 已通過自動化測試
![publicUnread(自動化測試)](https://user-images.githubusercontent.com/78346513/134799445-5e3d035c-02c5-47ca-b406-c083cbb18538.png)

- 已通過 POSTMAN 測試

1. 當前使用者為 55，登入時會收到公聊與私聊的未讀通知 (分別是布林值與數字)

![公開未讀(id 55 登入，收到未讀通知 (無新訊息))](https://user-images.githubusercontent.com/78346513/134799452-fc622b17-afc2-4313-a394-faa796a9e043.png)

2. 當前使用者為 35，已加入公開聊天室，id 55 發出訊息，35 成功收到訊息
![公開未讀(id 55 發訊息，id 35 在公聊，收到訊息)](https://user-images.githubusercontent.com/78346513/134799482-7018bd86-8966-4b91-816f-1bc9e11667b7.png)

3 當前使用者為 69，未加入公開聊天室，登入時公聊無未讀訊息 (false)，55 發出訊息後，公聊通知有未讀訊息 (true)
![公開未讀(id 69 登入時無新訊息，但未加入公聊，id 55 發訊息時收到通知變成 true)](https://user-images.githubusercontent.com/78346513/134799537-4807151e-d381-427a-aadb-34fdc1bcba8d.png)

4. 當前使用者為 69，加入公開聊天室，公開未讀通知正確改為已讀 (false) 
![公開未讀(id 69 加入公聊，未讀通知變為 false)](https://user-images.githubusercontent.com/78346513/134799610-1dd5b805-52f9-4d04-abd3-e08ebc68561c.png)
. 