### PR TITLE
feat: Modify getLatestMessages to return room data

### DIFF
--- a/controllers/messageController.js
+++ b/controllers/messageController.js
@@ -57,16 +57,16 @@ const messageController = {
         currentUserId
       )
 
-      latestMessages.forEach((message) => {
-        rooms.forEach((room) => {
+      rooms.forEach((room) => {
+        latestMessages.forEach((message) => {
           if (room.RoomId === message.RoomId) {
-            message.User = room.User
-            message.Room = room.Room
+            room.content = message.content
+            room.createdAt = message.createdAt
           }
         })
       })
 
-      return res.status(200).json(latestMessages)
+      return res.status(200).json(rooms)
     } catch (error) {
       next(error)
     }


### PR DESCRIPTION
修改:
- getLatestMessages的回傳格式，回先回傳latestMessages的資訊，但可能存在有建立room但彼此卻沒有訊息的狀況，因此修正為回傳room，當有latestMessages 時，則將message的資訊加入room的data中。

自動化測試:
![image](https://user-images.githubusercontent.com/24835719/134800598-c51db579-fc1e-4c53-811f-aaf17ebc7a4d.png)

Postman測試:

當前使用者為15，並且和使用者25、35存在著Room 15、25
![image](https://user-images.githubusercontent.com/24835719/134800845-7f902c2a-d339-40fb-a72c-8bc1f3c9ed9c.png)

當目前Room都沒有任何訊息時:
![image](https://user-images.githubusercontent.com/24835719/134800873-c8a9b11a-753b-4830-bb16-4029dee4e1d7.png)

只會回傳Room的資訊:
![image](https://user-images.githubusercontent.com/24835719/134800900-3cedda79-7b93-425e-8262-0d88fbadda44.png)

當目前Room 15 有訊息而25沒訊息時:
![image](https://user-images.githubusercontent.com/24835719/134800939-cd5c92b8-c480-48f8-8bc1-079dc7459f79.png)

其中Room 15會出現content 並將createAt 更新為此訊息的建立時間
![image](https://user-images.githubusercontent.com/24835719/134800953-8d3b0453-9147-4669-be07-852ac07fac9b.png)

當目前Room 15 、25有訊息時:
![image](https://user-images.githubusercontent.com/24835719/134801019-bee7a361-e268-49a4-a4f5-2b2f522d3965.png)

Room 15、25 會出現content 並將createAt 更新為此訊息的建立時間
![image](https://user-images.githubusercontent.com/24835719/134801033-13cda0a6-45c6-41d6-9ff4-0b4f9d6f0176.png)





