### PR TITLE
fix: correct getPrivateUnreadMessageCount where clause

### DIFF
--- a/services/messageService.js
+++ b/services/messageService.js
@@ -115,7 +115,14 @@ const messageService = {
       include: {
         model: Room,
         attributes: [],
-        where: { name: { [Op.substring]: currentUserId } }
+        where: {
+          name: {
+            [Op.or]: [
+              { [Op.like]: `${currentUserId}-%` },
+              { [Op.like]: `%-${currentUserId}` }
+            ]
+          }
+        }
       },
       where: {
         UserId: { [Op.not]: currentUserId },


### PR DESCRIPTION
先說聲不好意思，臨時送你一份 PR 禮包 QQ
不過挑戰已經結束了，你下班後有空再看就可以了！

修改：

- getPrivateUnreadMessageCount 的 where clause 修改為 Op.or 搭配 Op.like

狀況說明：

- 昨天過了 12 點後發現 User1 所有的私訊列表都已經讀過，但依然有 10 筆未讀訊息的詭異情況，查明後發現
原因是目前搜尋的方式是私聊房間名稱只要「包含」該使用者 id 就會被當作蒐尋對象。

以 User1 (id = 15) 的情況來說，115-65 這樣的房間名稱也會被當作符合的資料，
因為 1 "15"-65 本身也包含 15 這個值，但實際上這是 id = 115 和 id = 65 的房間，
所以會產生 User1 沒有看到 115-65 這個私訊列表 (也不該看到)，卻還是拿到他永遠也沒辦法讀取的未讀通知 

可能是我們本地的私聊房間太少了 XD ，所以沒發現這個漏洞 QQ ，
但其實只要私聊房間越開越多，使用者越註冊越多，應該會有更多使用者遇到同樣問題

測試：

- 已通過自動化測試
![不存在的未讀訊息自動化測試](https://user-images.githubusercontent.com/78346513/134817967-5cbb0a5d-4b3c-4c19-9631-5350e06b2e0f.png)
